### PR TITLE
0.1.1 update - does not count headers in code blocks

### DIFF
--- a/markdowndata/section_tree.py
+++ b/markdowndata/section_tree.py
@@ -9,7 +9,15 @@ def split_sections(text: str):
     Each section is identified by a header (e.g., #, ##, ###).
     """
     pattern = re.compile(r'^(?P<header>#+) (?P<title>[^\n]+)', re.MULTILINE)
-    matches = list(pattern.finditer(text))
+    code_spans = [match.span() for match in re.finditer(r'```.*?```', text, re.DOTALL)]
+
+    def is_in_code_block(pos: int) -> bool:
+        for start, end in code_spans:
+            if start <= pos < end:
+                return True
+        return False
+
+    matches = [match for match in pattern.finditer(text) if not is_in_code_block(match.start())]
 
     sections = []
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "markdowndata"
-version = "0.1.0"
+version = "0.1.1"
 description = "Tool to convert markdown tables into json objects"
 authors = ["Gordon Bean <gbean@cs.byu.edu>", "Robert Greathouse <robbykap@byu.edu>"]
 license = "MIT"

--- a/tests/test_data_structures.py
+++ b/tests/test_data_structures.py
@@ -122,3 +122,11 @@ def test_initial_dict():
         """,
         expected_data={'baz': 'quux', 'content': {'foo': 'bar'}}
     )
+
+
+
+def test_code_block_header_data():
+    build_test(
+        input_file="code_block_header_data.input.md",
+        expected_data_file="code_block_header_data.expected.json"
+    )

--- a/tests/test_files/code_block_header_data.expected.json
+++ b/tests/test_files/code_block_header_data.expected.json
@@ -1,0 +1,6 @@
+{
+  "Real Header": {
+    "Header 2": "```\n# Not a header\n```",
+    "content": "Body"
+  }
+}

--- a/tests/test_files/code_block_header_data.input.md
+++ b/tests/test_files/code_block_header_data.input.md
@@ -1,0 +1,9 @@
+# Real Header
+
+Body
+
+## Header 2
+
+```
+# Not a header
+```


### PR DESCRIPTION
Prior to this change, markdowndata considers code comments to be headers. 

``````md
# Real Header

Body

## Header 2

```
# Not a header
```
``````
For example, loading markdowndata on the above markdown results in the following: 

```
{
  'Not a header': '```', 
  'Real Header': {
  'Header 2': '```', 
  'content': 'Body'
  }
}
```
Note that "Not a header" is being considered a header. 

Following the change, it does not. 

```json
{
  "Real Header": {
    "Header 2": "```\n# Not a header\n```",
    "content": "Body"
  }
}
```

All other tests still pass: 

<img width="617" height="491" alt="image" src="https://github.com/user-attachments/assets/639a6257-b260-4fc8-9906-9cd8302f84f5" />


Attributions: Codex made the change and the first draft of the tests  